### PR TITLE
Now, if player has 0 amount of white rangers, the mission will fail

### DIFF
--- a/campaigns/human/level02h_c.sms
+++ b/campaigns/human/level02h_c.sms
@@ -32,6 +32,13 @@ AddTrigger(
   return true end)
 
 AddTrigger(
+function() return GetPlayerData(6, "UnitTypesCount", "unit-ranger") == 0 and
+             GetPlayerData(6, "UnitTypesCount", "unit-archer") == 0) and
+             GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-ranger") == 0 and
+             GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-archer") == 0) end,
+             function() return ActionDefeat() end)
+
+AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
 ]]


### PR DESCRIPTION
In the original triggers, if you can bring at least one white archer to circle of power, the player wins. But if player loses all white archers, the game doesn't end, and there's no way player can win. Therefore the mission gets stuck. This change could be considered a kind of finetuning that makes the mission automatically lost if all white archers are lost.
human/level02h.sms file (the file that determines the map) should also be edited in commemoration and white archers should be replaced with white rangers for these triggers to work.
