### PR TITLE
Removing faulty code in AI schedule

### DIFF
--- a/campaigns/orc-exp/levelx08o_c.sms
+++ b/campaigns/orc-exp/levelx08o_c.sms
@@ -75,7 +75,6 @@ local orc_exp_09_funcs = {
 	function() return AiResearch(AiUpgradeCatapult1()) end,
 	function() return AiResearch(AiUpgradeEliteShooter1()) end,
 	function() return AiResearch(AiUpgradeCatapult2()) end,
-	function() return AiResearch(AiUpgradeCatapult3()) end,
 	function() return AiSleep(6000) end,
 	
 	function() return AiForce(3, {AiSoldier(), 3, AiShooter(), 4, AiCavalry(), 5}) end,


### PR DESCRIPTION
"function() return AiResearch(AiUpgradeCatapult3()) end,"

Catapult upgrade 3 does not exist in warcraft. AI attempts to research this, and the game crashes after a certain amount of cycles. Removing that line fixes it.
