### PR TITLE
Fixing the false victory triggers in human btdp mission 6

### DIFF
--- a/campaigns/human-exp/levelx06h_c.sms
+++ b/campaigns/human-exp/levelx06h_c.sms
@@ -14,10 +14,7 @@ Briefing(
 
 Triggers = [[
 AddTrigger(
-  function() return GetPlayerData(0, "UnitTypesCount", "unit-orc-shipyard") == 0 and
-    GetPlayerData(2, "UnitTypesCount", "unit-orc-shipyard") == 0 and
-    GetPlayerData(4, "UnitTypesCount", "unit-orc-shipyard") == 0 and
-    GetPlayerData(5, "UnitTypesCount", "unit-orc-shipyard") == 0 and
+  function() return GetPlayerData(4, "TotalNumUnits") == 0 and
     IfRescuedNearUnit("this", "==", 1, "unit-arthor-literios", "unit-circle-of-power") and
     IfRescuedNearUnit("this", "==", 1, "unit-knight-rider", "unit-circle-of-power") end,
   function() return ActionVictory() end)


### PR DESCRIPTION
The original mission objectives state that "-Turalyon and Danath must return to the Circle of Power after destroying Bleeding Hollow (Orange)." But the former mission triggers dictated that you must destroy all orcish shipyards to win the game (like the previous mission). Just corrected that victory trigger.
