### PR TITLE
Fixing false victory triggers in human btdp mission 7

### DIFF
--- a/campaigns/human-exp/levelx07h_c.sms
+++ b/campaigns/human-exp/levelx07h_c.sms
@@ -14,10 +14,8 @@ Briefing(
 
 Triggers = [[
 AddTrigger(
-  function() return GetPlayerData(0, "TotalNumUnits") == 0 and
-    GetPlayerData(2, "TotalNumUnits") == 0 and
-    GetPlayerData(5, "TotalNumUnits") == 0 and
-    GetPlayerData(6, "TotalNumUnits") == 0 end,
+  function() return GetPlayerData(5, "UnitTypesCount", "unit-fire-breeze") == 0 and
+    GetPlayerData(5, "UnitTypesCount", "unit-dragon-roost") == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-white-mage") == 0 and


### PR DESCRIPTION
The original mission objectives state that: "-Rescue Kurdran","-Destroy Deathwing and his lair","-All heroes must survive" , but the former triggers dictated that you must destroy all enemy forces to win the game. Fixed victory triggers.
