### PR TITLE
Not a necessary change, but an improvement over original

### DIFF
--- a/campaigns/human-exp/levelx10h_c.sms
+++ b/campaigns/human-exp/levelx10h_c.sms
@@ -19,6 +19,9 @@ AddTrigger(
     GetPlayerData(6, "TotalNumUnits") == 0 end,
   function() return ActionVictory() end)
 AddTrigger(
+  function() return GetPlayerData(15, "UnitTypesCount", "unit-gold-mine") == 0 end,
+  function() return ActionVictory() end)
+AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
   function() return ActionDefeat() end)
 AddTrigger(


### PR DESCRIPTION
The original mission objectives state that "-Hold out until the besieging Orcs retreat", but nothing happens no matter how much you wait. This was also the case with the original warcraft, unfortunately. You had to eliminate all enemies in order to win the scenario.

So I've improved the code a bit without taking away the original victory condition. Now, you can either wait until all gold mines collapse (therefore you would have held out until the orcs have no currency left), OR destroy all enemy forces like in the original. Both are working and separate victory conditions.
