### PR TITLE
Defining ready upgrades

### DIFF
--- a/campaigns/human-exp/levelx12h_c.sms
+++ b/campaigns/human-exp/levelx12h_c.sms
@@ -162,6 +162,13 @@ DefineAllowOrcAlways()
 DefineAllow("upgrade-holy-vision", "RRRRRRRRRRRRRRRR")
 DefineAllow("upgrade-healing", "RRRRRRRRRRRRRRRR")
 DefineAllow("upgrade-exorcism", "RRRRRRRRRRRRRRRR")
+DefineAllow("upgrade-bloodlust", "RRRRRRRRRRRRRRRR")
+DefineAllow("upgrade-blizzard", "RRRRRRRRRRRRRRRR")
+DefineAllow("upgrade-polymorph", "RRRRRRRRRRRRRRRR")
+DefineAllow("upgrade-invisibility", "RRRRRRRRRRRRRRRR")
+DefineAllow("upgrade-flame-shield", "RRRRRRRRRRRRRRRR")
+DefineAllow("upgrade-slow", "RRRRRRRRRRRRRRRR")
+DefineAllow("upgrade-fireball", "RRRRRRRRRRRRRRRR")
 
 
 Load("campaigns/human-exp/levelx12h.sms")


### PR DESCRIPTION
In the original, mages and khadgar readily had all available spells without requiring an upgrade. That lacked in wargus version. Fixed that now.
