### PR TITLE
Victory condition triggers and define allow fixed

### DIFF
--- a/campaigns/human-exp/levelx03h_c.sms
+++ b/campaigns/human-exp/levelx03h_c.sms
@@ -13,8 +13,13 @@ Briefing(
 
 Triggers = [[
 AddTrigger(
-  function() return GetNumOpponents(GetThisPlayer()) == 0 and
-    GetPlayerData(GetThisPlayer(), "UnitTypesCount", "unit-knight-rider") == 1 end,
+  function() return GetPlayerData(0, "UnitTypesCount", "unit-stronghold") == 0 and
+  GetPlayerData(0, "UnitTypesCount", "unit-fortress") == 0 and
+  GetPlayerData(3, "UnitTypesCount", "unit-stronghold") == 0 and
+  GetPlayerData(3, "UnitTypesCount", "unit-fortress") == 0 and 
+  GetPlayerData(4, "UnitTypesCount", "unit-stronghold") == 0 and
+  GetPlayerData(4, "UnitTypesCount", "unit-fortress") == 0 and
+  IfRescuedNearUnit("this", "==", 1, "unit-knight-rider", "unit-circle-of-power") end,
   function() return ActionVictory() end)
 AddTrigger(
   function() return GetPlayerData(GetThisPlayer(), "TotalNumUnits") == 0 end,
@@ -35,6 +40,10 @@ DefineAllowExtraOrcUnits("FFFFFFFFFFFFFFFF")
 DefineAllowSpecialUnits("FFFFFFFFFFFFFFFF")
 DefineAllowHumanAlways()
 DefineAllowOrcAlways()
+
+DefineAllow("upgrade-holy-vision", "RRRRRRRRRRRRRRRR")
+DefineAllow("upgrade-healing", "RRRRRRRRRRRRRRRR")
+DefineAllow("upgrade-exorcism", "RRRRRRRRRRRRRRRR")
 
 local hum_exp_03a_loop_funcs = {
 	function() DebugPrint("Looping !\n") return false end,


### PR DESCRIPTION
In the original, the mission objectives were "-Destroy all strongholds and fortresses","-Turalyon must reach the Dark Portal alive". But the former triggers dictated that you must eliminate all enemy units in order to win, not just strongholds and fortresses. Also added Turalyon reaching the circle of power condition as the former triggers didn't have that. And added all paladin spells to be readily available from start, as that was how it was for this mission in the original.
